### PR TITLE
Fix race condition when multiple targets utilize the same local property name

### DIFF
--- a/src/main/java/org/codeaholics/tools/build/pant/AntWrapperImpl.java
+++ b/src/main/java/org/codeaholics/tools/build/pant/AntWrapperImpl.java
@@ -18,10 +18,15 @@ package org.codeaholics.tools.build.pant;
 
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
+import org.apache.tools.ant.property.LocalProperties;
 
 public class AntWrapperImpl implements AntWrapper {
     @Override
     public void executeTarget(final Target target) {
+        // Ensure a copy of the LocalProperties is performed before invoking the
+        // target to prevent data races from multiple targets invoked in parallel.
+        LocalProperties.get(target.getProject()).copy();
+
         target.performTasks();
     }
 


### PR DESCRIPTION
This change applies the same technique used in the core Ant Parallel Task source to ensure a copy of the LocalProperties is made before the target is executed.

Prior to this, two or more targets that set local property values would actually be sharing the same property rather than their own copies. This would cause race conditions on the property values (one target could write a value that another would see) when running with Parallel-Ant.