### PR TITLE
Add build failure notification support

### DIFF
--- a/src/main/java/org/codeaholics/tools/build/pant/DependencyGraphEntry.java
+++ b/src/main/java/org/codeaholics/tools/build/pant/DependencyGraphEntry.java
@@ -19,6 +19,7 @@ package org.codeaholics.tools.build.pant;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Target;
 
 public class DependencyGraphEntry implements Runnable {
@@ -87,6 +88,8 @@ public class DependencyGraphEntry implements Runnable {
         executionNotifier.notifyStarting(this);
         try {
             targetExecutor.executeTarget(target);
+        } catch (BuildException e) {
+            executionNotifier.notifyException(this, e);
         } finally {
             executionNotifier.notifyComplete(this);
         }

--- a/src/main/java/org/codeaholics/tools/build/pant/TargetExecutionNotifier.java
+++ b/src/main/java/org/codeaholics/tools/build/pant/TargetExecutionNotifier.java
@@ -16,7 +16,10 @@ package org.codeaholics.tools.build.pant;
  *   limitations under the License.
  */
 
+import org.apache.tools.ant.BuildException;
+
 public interface TargetExecutionNotifier {
     public void notifyStarting(DependencyGraphEntry dependencyGraphEntry);
     public void notifyComplete(DependencyGraphEntry dependencyGraphEntry);
+    public void notifyException(DependencyGraphEntry dependencyGraphEntry, BuildException e);
 }


### PR DESCRIPTION
This adds support for collecting (potentially) multiple BuildExceptions that can occur when executing multiple targets at once, combining them into a single exception string and throwing a single BuildException to Ant. This provides each failure's stacktrace in a newline delimited format for the user to investigate.

Additionally, if a BuildException does occur the executor is signaled to shutdown, stopping the build once the remaining targets that are currently running have completed.